### PR TITLE
feat(xml): print out processing instructions

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -78,3 +78,35 @@ test('should not introduce line break if text node is empty', () => {
 `
   );
 });
+
+test('should print out xml declarations', () => {
+  const html = `<?xml version="1.0" encoding="utf-8"?>`;
+
+  expect(format(html)).toEqual(
+    `
+<?xml version="1.0" encoding="utf-8"?>
+`
+  );
+});
+
+test('should print out doctype', () => {
+  const html = `<!DOCTYPE html>`;
+
+  expect(format(html)).toEqual(
+    `
+<!DOCTYPE html>
+`
+  );
+});
+
+test('should not indent after a directive', () => {
+  const html = `<!DOCTYPE html><html></html>`;
+
+  expect(format(html)).toEqual(
+    `
+<!DOCTYPE html>
+<html>
+</html>
+`
+  );
+});

--- a/index.js
+++ b/index.js
@@ -83,6 +83,11 @@ const format = function(html) {
       elements.push(' '.repeat(indentSize * currentIndentation));
       elements.push(`</${tagname}>`);
     },
+    onprocessinginstruction: function(name, data) {
+      elements.push('\n');
+      elements.push(' '.repeat(indentSize * currentIndentation));
+      elements.push(`<${data}>`);
+    },
   });
   parser.write(html);
   parser.end();


### PR DESCRIPTION
Both doctype declarations and xml declarations are processing instructions and parsed as a simple string in the AST, so the best option is to simply print them out in a single line.