### PR TITLE
feat(xml): handle self closing tags as real tags

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -112,6 +112,19 @@ test('should support xml', () => {
 `);
 });
 
+test('should keep self-closing tags as they are', () => {
+  const xml = `<xhtml:link href="https://en.example.com" /><xhtml:link href="https://en.example.com" />`;
+
+  // in the future this should be a self closing tag instead
+  // see htmlparser2#69
+  expect(format(xml)).toEqual(`
+<xhtml:link href="https://en.example.com">
+</xhtml:link>
+<xhtml:link href="https://en.example.com">
+</xhtml:link>
+`);
+});
+
 test('should support doctype directives', () => {
   const html = `<!doctype html ><html></html>`;
   expect(format(html)).toEqual(`
@@ -119,8 +132,7 @@ test('should support doctype directives', () => {
 <html>
 </html>
 `);
-
-})
+});
 
 test('should support html directives', () => {
   const html = `<!doctype html>

--- a/index.js
+++ b/index.js
@@ -236,6 +236,7 @@ const format = function(html) {
     },
     {
       lowerCaseTags: false,
+      recognizeSelfClosing: true,
     }
   );
   parser.write(html);


### PR DESCRIPTION
I'd love to be able to recognize the self-closing tags and keep them that way, but as a first step, this will make the output compliant. Before this change, the output would be:

```xml
<xhtml:link href="https://en.example.com">
  <xhtml:link href="https://en.example.com">
  </xhtml:link>
</xhtml:link>
```

Right now it's going to be correct and correctly indented xml:

```xml
<xhtml:link href="https://en.example.com">
</xhtml:link>
<xhtml:link href="https://en.example.com">
</xhtml:link>
```
