### PR TITLE
Trim space characters but not Unicode whitespace

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -68,6 +68,18 @@ test('should trim text nodes', () => {
   );
 });
 
+test('should not trim Unicode whitespace', () => {
+  const html = `<span> \u2009 surrounded  \u2005\u200a  </span>`;
+
+  expect(format(html)).toEqual(
+    `
+<span>
+  \u2009 surrounded  \u2005\u200a
+</span>
+`
+  );
+});
+
 test('should not introduce line break if text node is empty', () => {
   const html = `<span>     </span>`;
 

--- a/index.js
+++ b/index.js
@@ -151,6 +151,12 @@ const format = function(html) {
     return voidElements.indexOf(name) !== -1;
   };
 
+  // https://www.w3.org/TR/html52/infrastructure.html#space-characters
+  // defines "space characters" to include SPACE, TAB, LF, FF, and CR.
+  const trimText = text => {
+    return text.replace(/^[ \t\n\f\r]+|[ \t\n\f\r]+$/g, '');
+  }
+
   const extractAttributesFromString = content => {
     const attributes = {};
 
@@ -205,7 +211,7 @@ const format = function(html) {
         appendClosingTag(attributes, '>');
       },
       ontext: function(text) {
-        const trimmed = text.trim();
+        const trimmed = trimText(text);
         if (trimmed.length === 0) {
           return;
         }


### PR DESCRIPTION
Fix #14 by trimming only [HTML's definition of space characters](https://www.w3.org/TR/html52/infrastructure.html#space-characters) instead of Unicode (JavaScript)'s definition of whitespace.

I did a [quick speed test](http://jsben.ch/qgjL1) and it seems that this code actually runs 35% faster (in Chrome).  So regular expressions seem like a good way to go.