### PR TITLE
feat: add sortAttributes option

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -263,3 +263,16 @@ test('should not strip out conditional comments', () => {
 `
   );
 });
+
+test('should order attributes alphabetically', () => {
+  const html = `<input name="test" value="true" class="form-control">`;
+
+  expect(format(html, { sortAttributes: true })).toEqual(
+    `
+<input class="form-control"
+       name="test"
+       value="true"
+>
+`
+  );
+});

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const voidElements = [
   'wbr',
 ];
 
-const format = function(html) {
+const format = function(html, { sortAttributes = false } = {}) {
   const elements = [];
   const indentSize = 2;
 
@@ -109,7 +109,10 @@ const format = function(html) {
   };
 
   const appendAttributes = (attributes, tagName) => {
-    const names = Object.keys(attributes);
+    let names = Object.keys(attributes);
+    if (sortAttributes) {
+      names = names.sort();
+    }
 
     if (names.length === 1) {
       appendAttribute(names[0], attributes[names[0]]);
@@ -120,7 +123,7 @@ const format = function(html) {
     }
 
     let firstAttribute = true;
-    for (let name in attributes) {
+    for (let name of names) {
       if (firstAttribute === true) {
         firstAttribute = false;
         appendAttribute(name, attributes[name]);


### PR DESCRIPTION
## Summary

Hello,

This PR adds an option `sortAttributes` to literally sort attributes in the output.

fixes https://github.com/rayrutjes/diffable-html/issues/30

It's `false` by default, so it won't break anyone's test. I've lately ran into this blocker. Working on support of Vue 3 in Vue InstantSearch, I've noticed the serialized html outputs (either from vue or vue test utils) have changed the order of attributes.

I'm not sure if it's intended by vue (or vue test utils), but by having a way to sort attributes at the testing layer, I can maintain the same snapshots for both vue 2 and vue 3.

Could you consider this PR? :)